### PR TITLE
Remove uuid unsigned constraint from token table migration

### DIFF
--- a/database/migrations/2014_10_12_100000_create_tokens_table.php
+++ b/database/migrations/2014_10_12_100000_create_tokens_table.php
@@ -17,7 +17,7 @@ class CreateTokensTable extends Migration
             $table->string('token');
             $table->primary('token');
             $table->string('type');
-            $table->uuid('user_id')->unsigned();
+            $table->uuid('user_id');
             $table->foreign('user_id')->references('id')->on('users');
             $table->timestamp('created_at')->nullable();
         });


### PR DESCRIPTION
Removed unsigned constraint from the user_id field. In MySQL/MariaDB, the uuid field type is CHAR, which does not support unsigned.